### PR TITLE
feat: add CloudWatch monitoring and alerting for EKS node groups to match DigitalOcean infra

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,0 +1,51 @@
+data "aws_autoscaling_groups" "eks_nodegroups" {
+  filter {
+    name   = "tag:eks:cluster-name"
+    values = [module.eks.cluster_name]
+  }
+}
+
+resource "aws_sns_topic" "alerts" {
+  name = "${module.eks.cluster_name}-alerts"
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "email"
+  endpoint  = "your-alert-email@example.com" # <-- CHANGE THIS to your email
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu_high" {
+  for_each            = toset(data.aws_autoscaling_groups.eks_nodegroups.names)
+  alarm_name          = "${each.key}-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 90
+  alarm_description   = "CPU is running high on EKS worker nodes"
+  dimensions = {
+    AutoScalingGroupName = each.key
+  }
+  alarm_actions = [aws_sns_topic.alerts.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "memory_high" {
+  for_each            = toset(data.aws_autoscaling_groups.eks_nodegroups.names)
+  alarm_name          = "${each.key}-memory-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "mem_used_percent"
+  namespace           = "CWAgent"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 90
+  alarm_description   = "Memory utilization is running high on EKS worker nodes"
+  dimensions = {
+    AutoScalingGroupName = each.key
+  }
+  alarm_actions = [aws_sns_topic.alerts.arn]
+}
+


### PR DESCRIPTION
### Feat: Add CloudWatch Monitoring and Alerting for EKS Node Groups

### Description
This PR introduces CloudWatch-based monitoring and alerting for EKS worker node groups in the AWS Terraform infrastructure, aligning it with the DigitalOcean infrastructure’s resource utilization alerts.

### Why is this change needed?

- To provide parity with DigitalOcean’s CPU and memory alerting for Kubernetes worker nodes.
- To enable proactive monitoring and notifications for high resource utilization in AWS EKS clusters.
- To ensure infrastructure consistency across cloud providers.

### What does this PR do?

- Adds a new **cloudwatch.tf** file.
- Configures CloudWatch alarms for high CPU and memory usage (threshold: 90%) on all EKS node groups.
- Sets up an SNS topic and email subscription for alert notifications.
- Ensures alarm actions and notification flow match the DigitalOcean monitoring setup.
- No changes to existing cluster, node group, or add-on configuration.

### Documentation

- The SNS email address can be configured in **cloudwatch.tf**.
- Memory alarms require the CloudWatch Agent to be installed on EKS nodes.
- No changes required to existing usage or deployment workflows.